### PR TITLE
Adding export file creation.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -20,6 +20,6 @@ After running this command, you need to run the following command:
 `source ./source.sh`
 
 To initialize a Terraform backend on a specific lesson run:
-`python3 awsconfig.py-i -l <lesson-folder>`
+`python3 awsconfig.py -i -l <lesson-folder>`
 
 Lesson accepted values are `lesson01`, `lesson02` or `lesson03`.

--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,9 @@ After this, you need to create a `variables.ini` file, following the same format
 To configure your AWS credentials run:
 `python3 awsconfig.py`
 
+After running this command, you need to run the following command:
+`source ./source.sh`
+
 To initialize a Terraform backend on a specific lesson run:
 `python3 awsconfig.py-i -l <lesson-folder>`
 

--- a/python/awsconfig.py
+++ b/python/awsconfig.py
@@ -94,6 +94,7 @@ def create_user_export_file(aws_profile, aws_region="us-east-2"):
     with open(os.open(file_path, os.O_CREAT | os.O_WRONLY, 0o755), 'w') as efh:
         efh.write("export AWS_PROFILE=" + aws_profile + "\n")
         efh.write("export AWS_REGION=" + aws_region + "\n")
+    print('Now please run source ./source.sh')
 
 def get_aws_user(aws_key, aws_secret):
     """

--- a/python/awsconfig.py
+++ b/python/awsconfig.py
@@ -81,6 +81,20 @@ def update_aws_config(profile, output, region):
     with open(config_file, 'w+') as new_config_file:
         config.write(new_config_file)
 
+def create_user_export_file(aws_profile, aws_region="us-east-2"):
+    """
+    Creates an export file for the AWS Profile and AWS Region env
+    variables.
+    :param aws_profile: AWS profile created in the .aws/config files
+    :param aws_region: AWS region where the resources will be created
+    :return:
+    """
+    os.umask(0)
+    file_path = "./export.sh"
+    with open(os.open(file_path, os.O_CREAT | os.O_WRONLY, 0o755), 'w') as efh:
+        efh.write("export AWS_PROFILE=" + aws_profile + "\n")
+        efh.write("export AWS_REGION=" + aws_region + "\n")
+
 def get_aws_user(aws_key, aws_secret):
     """
     Gets aws user name depending on the aws access key id.
@@ -130,6 +144,7 @@ def main(variables):
     update_aws_credentials(prof, aws_key, aws_sec, '')
     update_aws_config(prof, 'json', 'us-east-2')
     print("Profile updated successfully")
+    create_user_export_file(prof)
     sys.exit(0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Source Script.

#### What does this PR do?

- Creates a new `source.sh` file to export the environment variables `AWS_REGION` and `AWS_PROFILE`.
- Updates `README.md`.

#### Where should the reviewers start?

- python/awsconfig.py
- python/README.md

#### How should this be manually tested?

- Clone the repository to your local environment.
- Checkout the branch `git checkout feat/terraform-init`
- Change directory to the python directory `cd python`
- Install virtualenv using Python3 `pip3 install virtualenv`
- Create the virtual environment in your python directory `python3 -m venv .`
- Activate your environment `source bin/activate`
- Install dependencies `pip3 install -r requirements.txt`
-  Run the command to update the credentials `python3 awsconfig.py`
- Run the command `source ./export.sh`.

#### Any background context you want to provide?

This script solves a problem that the AWS region and profile aren't exported, hence, terraform tries to start the scripts in the default region and profile. 

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [X] I added the necessary documentation, if appropriate.
- [X] I reviewed existing Pull Requests before submitting mine.
- [X] It sparks joy.
