### PR TITLE
Cloud9 bootstraping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ version: 2
             apk add jq wget curl
             # Get latest version of tflint (v0.7.0 test if still need to exclude modules. Any other changes)
             pkg_arch=linux_amd64
-            dl_url=$(curl -s https://api.github.com/repos/wata727/tflint/releases/latest | jq -r ".assets[] | select(.name | test(\"${pkg_arch}\")) | .browser_download_url")
+            dl_url=$(curl -s -L https://api.github.com/repos/wata727/tflint/releases/latest | jq -r ".assets[] | select(.name | test(\"${pkg_arch}\")) | .browser_download_url")
             wget ${dl_url}
             unzip tflint_linux_amd64.zip
             mkdir -p /usr/local/tflint/bin

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/gitpitch/the-template/blob/master/PITCHME.md
 
 Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), just click _Next_, _Next_, _Next_ and _Create Stack_:
 
-[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=TerraformAcademy&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=TerraformAcademy&templateURL=https://terraform-wizeline-academy.s3.amazonaws.com/cloud9-cfn-template.yaml)
 
 Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside the AWS console and click _Open IDE_ on your new environment called **TerraformAcademy**.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 # Terraform Academy
 
-
 # Template Examples
+
 https://github.com/gitpitch/the-template/blob/master/PITCHME.md
+
+## Using Cloud9
+
+Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), name the stack **TerraformAcademy**:
+
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=terraform-lab-env&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
+
+Go to your Cloud9 service inside the AWS console and click on your new environment called **TerraformAcademy**.
+
+Once inside use the terminal to install Terraform 0.12 with the following command:
+
+```
+cat /dev/null
+```
+
+Your files are located inside the repo folder.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside t
 Once inside, use the terminal to install Terraform 0.12 with the following commands:
 
 ```
-cat /dev/null
+mkdir -p $HOME/bin && cd $HOME/bin
+wget https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip
+unzip terraform_0.12.19_linux_amd64.zip
+echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.bashrc && source $HOME/.bashrc
+cd $HOME/environment/terraform-academy
+terraform version
 ```
 
 You can start working with the files located in the **terraform-academy** folder.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ https://github.com/gitpitch/the-template/blob/master/PITCHME.md
 
 ## Using Cloud9
 
-Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), just click Next, Next, Next and Create Stack:
+Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), just click _Next_, _Next_, _Next_ and _Create Stack_:
 
-[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=Terraform-Academy&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=TerraformAcademy&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
 
-Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside the AWS console and click on your new environment called **Terraform-Academy**.
+Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside the AWS console and click _Open IDE_ on your new environment called **TerraformAcademy**.
 
-Once inside use the terminal to install Terraform 0.12 with the following command:
+Once inside, use the terminal to install Terraform 0.12 with the following commands:
 
 ```
 cat /dev/null
 ```
 
-You can start working with the files located in the repo folder.
+You can start working with the files located in the **terraform-academy** folder.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use the following CloudFormation template to setup a Cloud9 environment in us-ea
 
 [![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=Terraform-Academy&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
 
-Go to your Cloud9 service inside the AWS console and click on your new environment called **Terraform-Academy**.
+Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside the AWS console and click on your new environment called **Terraform-Academy**.
 
 Once inside use the terminal to install Terraform 0.12 with the following command:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 https://github.com/gitpitch/the-template/blob/master/PITCHME.md
 
-## Using Cloud9
+## Using Cloud9 (optional)
 
 Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), just click _Next_, _Next_, _Next_ and _Create Stack_:
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ https://github.com/gitpitch/the-template/blob/master/PITCHME.md
 
 ## Using Cloud9
 
-Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), name the stack **TerraformAcademy**:
+Use the following CloudFormation template to setup a Cloud9 environment in us-east-1 (N. Virginia), just click Next, Next, Next and Create Stack:
 
-[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=terraform-lab-env&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=Terraform-Academy&templateURL=https://cloudtitlan-public-cfn-templates.s3.amazonaws.com/terraform-academy.yaml)
 
-Go to your Cloud9 service inside the AWS console and click on your new environment called **TerraformAcademy**.
+Go to your Cloud9 service inside the AWS console and click on your new environment called **Terraform-Academy**.
 
 Once inside use the terminal to install Terraform 0.12 with the following command:
 
@@ -20,4 +20,4 @@ Once inside use the terminal to install Terraform 0.12 with the following comman
 cat /dev/null
 ```
 
-Your files are located inside the repo folder.
+You can start working with the files located in the repo folder.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,8 @@ Go to your [Cloud9 service](https://console.aws.amazon.com/cloud9/home) inside t
 Once inside, use the terminal to install Terraform 0.12 with the following commands:
 
 ```
-mkdir -p $HOME/bin && cd $HOME/bin
 wget https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip
-unzip terraform_0.12.19_linux_amd64.zip
-echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.bashrc && source $HOME/.bashrc
-cd $HOME/environment/terraform-academy
+unzip terraform_0.12.19_linux_amd64.zip && sudo mv terraform /usr/local/bin && rm -f terraform_0.12.19_linux_amd64.zip
 terraform version
 ```
 


### PR DESCRIPTION
Adds a README section with a CloudFormation Stack button to setup a Cloud9 environment with the repository installed.

This alleviate some pain points I have seen during the workshop:

- Install git and clone the repo
- Install Terraform locally
- Configure IAM user, install awscli and configure it
- Unable to run the `local-exec` provisioner because of some OS incompatibility