### PR TITLE
Increase local-exec provisioner timeout

### DIFF
--- a/slides/lesson1/solution/main.tf
+++ b/slides/lesson1/solution/main.tf
@@ -64,7 +64,7 @@ resource "aws_instance" "web" {
   # This step will execute a command on our local machine,
   # it will wait until the EC2 instance is ready to work.
   provisioner "local-exec" {
-    command = "bash -c 'MAX=10; C=0; until curl -s -o /dev/null ${aws_instance.web.public_dns}; do [ $C -eq $MAX ] && { exit 1; } || sleep 10; ((C++)); done;' || false"
+    command = "bash -c 'MAX=20; C=0; until curl -s -o /dev/null ${aws_instance.web.public_dns}; do [ $C -eq $MAX ] && { exit 1; } || sleep 10; ((C++)); done;' || false"
   }
 
   # Command used to set up our instance, will install docker and

--- a/slides/lesson1/solution/main_hard_code.tf
+++ b/slides/lesson1/solution/main_hard_code.tf
@@ -72,7 +72,7 @@ resource "aws_instance" "web" {
   # This step will execute a command on our local machine,
   # it will wait until the EC2 instance is ready to work.
   provisioner "local-exec" {
-    command = "bash -c 'MAX=10; C=0; until curl -s -o /dev/null ${aws_instance.web.public_dns}; do [ $C -eq $MAX ] && { exit 1; } || sleep 10; ((C++)); done;' || false"
+    command = "bash -c 'MAX=20; C=0; until curl -s -o /dev/null ${aws_instance.web.public_dns}; do [ $C -eq $MAX ] && { exit 1; } || sleep 10; ((C++)); done;' || false"
   }
 
   # Command used to set up our instance, will install docker and


### PR DESCRIPTION
I've seen that 100 seconds is not enough time to allow the container to start and the `apply` is marked as failed. This PR increase local-exec provisioner max time to 200 seconds which is more than enough.

Slides updated:

https://gitpitch.com/wizelineacademy/terraform-academy/increase-provisioner-time#/24